### PR TITLE
breaking: require caller-supplied aws.primary provider configuration #major

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ No modules.
 |------|------|
 | [aws_kms_key.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The AWS Account ID | `string` | n/a | yes |
+| <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | DEPRECATED: no longer used. The aws.primary provider configuration is supplied by the caller now; this variable remains only so existing callers keep working. | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,25 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.primary]
+    }
+  }
+}
+
 data "aws_caller_identity" "current" {
   provider = aws.primary
 }
 
-variable "aws_account_id" {
-  description = "The AWS Account ID"
-  type        = string
-  nullable    = false
+data "aws_region" "primary" {
+  provider = aws.primary
 }
 
-provider "aws" {
-  alias  = "primary"
-  region = "us-east-1"
-  assume_role {
-    role_arn = "arn:aws:iam::${var.aws_account_id}:role/OrganizationAccountAccessRole"
-  }
+variable "aws_account_id" {
+  description = "DEPRECATED: no longer used. The aws.primary provider configuration is supplied by the caller now; this variable remains only so existing callers keep working."
+  type        = string
+  nullable    = true
+  default     = null
 }
 
 resource "aws_kms_key" "primary" {
@@ -51,6 +57,13 @@ resource "aws_kms_key" "primary" {
     ]
     Version = "2012-10-17"
   })
+
+  lifecycle {
+    precondition {
+      condition     = data.aws_region.primary.name == "us-east-1"
+      error_message = "Route53 DNSSEC requires its KMS key in us-east-1. Pass an aws.primary provider configured for us-east-1."
+    }
+  }
 }
 
 output "kms_key_arn" {


### PR DESCRIPTION
Removes the last internally-configured provider in the tenant/captain module stack (context: GlueOps/terraform-module-cloud-multy-prerequisites#662, which moved all provider configuration up to tenant repos).

## What changes

- The internal `provider "aws" { alias = "primary" … }` block (hardcoded `us-east-1` + `OrganizationAccountAccessRole` assume-role) is removed; the module now declares `configuration_aliases = [aws.primary]` and callers pass the provider:

  ```hcl
  provider "aws" {
    alias  = "dnssec-us-east-1"
    region = "us-east-1"   # AWS requires Route53 DNSSEC KMS keys in us-east-1
    assume_role { role_arn = "arn:aws:iam::<account>:role/OrganizationAccountAccessRole" }
  }

  module "dnssec_key" {
    source    = "git::https://github.com/GlueOps/terraform-module-cloud-aws-dnssec-kms-key.git?ref=vX.Y.Z"
    providers = { aws.primary = aws.dnssec-us-east-1 }
  }
  ```

- A `precondition` preserves the intent of the old hardcode: any `aws.primary` provider not in `us-east-1` fails the plan with an explanatory error (Route53 DNSSEC requires the key there).
- `aws_account_id` is now deprecated and ignored — kept (nullable, defaulted) so existing callers don't break on upgrade. The KMS key policy already derives the account id from the provider identity, so behavior is unchanged.

## Why

**Breaking** for consumers (they must add the `providers` map when bumping to this version — hence `#major`). Modules with internal provider configurations can't be cleanly removed (orphaned state needs the vanished provider config to destroy — the classic `Provider configuration not present` failure) and block `for_each`/`count` on their callers. This was the last such case in the stack; after this, provider configuration lives exclusively in tenant repo roots.

## Consumer follow-up

`terraform-module-cloud-multy-prerequisites` will bump to this version in a follow-up: `modules/tenant-base` gains the fifth alias in its `configuration_aliases` and forwards it; the backwards-compatible wrapper configures it internally so `ref=main` tenants are unaffected; migrated tenants add the fifth provider block (template already staged). No resource changes — the KMS key stays byte-identical, so consumer plans must remain `0 to add, 0 to change, 0 to destroy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)